### PR TITLE
[WIP] bpf: Add options to install custom IP filter programs

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -31,8 +31,11 @@ fresh build of the project in the local working directory. To make use of this,
 please acquire `mkosi` from https://github.com/systemd/mkosi first, unless your
 distribution has packaged it already and you can get it from there. After the
 tool is installed it is sufficient to type `mkosi` in the systemd project
-directory to generate a disk image `image.raw` you can boot either in
-`systemd-nspawn` or in an UEFI-capable VM:
+directory to generate a disk image `image.raw`. If you are using a different
+distribution there are several extra config files provided in `.mkosi`. If you
+want to build for Debian for example, use `mkosi --default
+.mkosi/mkosi.debian`. You can boot either in `systemd-nspawn` or in an
+UEFI-capable VM:
 
 ```
 # systemd-nspawn -bi image.raw
@@ -75,7 +78,8 @@ $ meson build                          # configure the build
 $ ninja -C build                       # build it locally, see if everything compiles fine
 $ ninja -C build test                  # run some simple regression tests
 $ (umask 077; echo 123 > mkosi.rootpw) # set root password used by mkosi
-$ sudo mkosi                           # build a test image
+$ sudo mkosi                           # build a test image, add --default
+                                       # .mkosi/mkosi.<dist> if needed
 $ sudo systemd-nspawn -bi image.raw    # boot up the test image
 $ git add -p                           # interactively put together your patch
 $ git commit                           # commit it

--- a/src/core/bpf-firewall.h
+++ b/src/core/bpf-firewall.h
@@ -13,7 +13,7 @@ enum {
 
 int bpf_firewall_supported(void);
 
-int bpf_firewall_compile(Unit *u);
+int bpf_firewall_prepare(Unit *u);
 int bpf_firewall_install(Unit *u);
 
 int bpf_firewall_read_accounting(int map_fd, uint64_t *ret_bytes, uint64_t *ret_packets);

--- a/src/core/cgroup.h
+++ b/src/core/cgroup.h
@@ -78,6 +78,8 @@ struct CGroupContext {
         bool memory_accounting;
         bool tasks_accounting;
         bool ip_accounting;
+        bool ip_ingress_filter_bpf;
+        bool ip_egress_filter_bpf;
 
         /* For unified hierarchy */
         uint64_t cpu_weight;

--- a/src/core/load-fragment-gperf.gperf.m4
+++ b/src/core/load-fragment-gperf.gperf.m4
@@ -196,6 +196,8 @@ $1.DisableControllers,           config_parse_disable_controllers,   0,         
 $1.IPAccounting,                 config_parse_bool,                  0,                             offsetof($1, cgroup_context.ip_accounting)
 $1.IPAddressAllow,               config_parse_ip_address_access,     0,                             offsetof($1, cgroup_context.ip_address_allow)
 $1.IPAddressDeny,                config_parse_ip_address_access,     0,                             offsetof($1, cgroup_context.ip_address_deny)
+$1.IPIngressFilterBPF,           config_parse_bool,                  0,                             offsetof($1, cgroup_context.ip_ingress_filter_bpf)
+$1.IPEgressFilterBPF,            config_parse_bool,                  0,                             offsetof($1, cgroup_context.ip_egress_filter_bpf)
 $1.NetClass,                     config_parse_warn_compat,           DISABLED_LEGACY,               0'
 )m4_dnl
 Unit.Description,                config_parse_unit_string_printf,    0,                             offsetof(Unit, description)

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -130,6 +130,8 @@ static bool arg_default_tasks_accounting = true;
 static uint64_t arg_default_tasks_max = UINT64_MAX;
 static sd_id128_t arg_machine_id = {};
 static EmergencyAction arg_cad_burst_action = EMERGENCY_ACTION_REBOOT_FORCE;
+static bool arg_default_ip_ingress_filter_bpf = false;
+static bool arg_default_ip_egress_filter_bpf = false;
 
 _noreturn_ static void freeze_or_exit_or_reboot(void) {
 
@@ -720,6 +722,8 @@ static int parse_config_file(void) {
                 { "Manager", "DefaultTasksAccounting",    config_parse_bool,             0, &arg_default_tasks_accounting          },
                 { "Manager", "DefaultTasksMax",           config_parse_tasks_max,        0, &arg_default_tasks_max                 },
                 { "Manager", "CtrlAltDelBurstAction",     config_parse_emergency_action, 0, &arg_cad_burst_action                  },
+                { "Manager", "DefaultIPIngressFilterBPF", config_parse_bool,             0, &arg_default_ip_ingress_filter_bpf     },
+                { "Manager", "DefaultIPEgressFilterBPF",  config_parse_bool,             0, &arg_default_ip_egress_filter_bpf      },
                 {}
         };
 
@@ -775,6 +779,9 @@ static void set_manager_defaults(Manager *m) {
         m->default_memory_accounting = arg_default_memory_accounting;
         m->default_tasks_accounting = arg_default_tasks_accounting;
         m->default_tasks_max = arg_default_tasks_max;
+
+        m->default_ip_ingress_filter_bpf = arg_default_ip_ingress_filter_bpf;
+        m->default_ip_egress_filter_bpf = arg_default_ip_egress_filter_bpf;
 
         (void) manager_set_default_rlimits(m, arg_default_rlimit);
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -325,6 +325,9 @@ struct Manager {
         bool default_tasks_accounting;
         bool default_ip_accounting;
 
+        bool default_ip_ingress_filter_bpf;
+        bool default_ip_egress_filter_bpf;
+
         uint64_t default_tasks_max;
         usec_t default_timer_accuracy_usec;
 

--- a/src/core/system.conf.in
+++ b/src/core/system.conf.in
@@ -46,6 +46,8 @@
 #DefaultMemoryAccounting=@MEMORY_ACCOUNTING_DEFAULT@
 #DefaultTasksAccounting=yes
 #DefaultTasksMax=15%
+#DefaultIPIngressFilterBPF=no
+#DefaultIPEgressFilterBPF=no
 #DefaultLimitCPU=
 #DefaultLimitFSIZE=
 #DefaultLimitDATA=

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -162,6 +162,8 @@ static void unit_init(Unit *u) {
                 cc->blockio_accounting = u->manager->default_blockio_accounting;
                 cc->memory_accounting = u->manager->default_memory_accounting;
                 cc->tasks_accounting = u->manager->default_tasks_accounting;
+                cc->ip_ingress_filter_bpf = u->manager->default_ip_ingress_filter_bpf;
+                cc->ip_egress_filter_bpf = u->manager->default_ip_egress_filter_bpf;
 
                 if (u->type != UNIT_SLICE)
                         cc->tasks_max = u->manager->default_tasks_max;

--- a/src/core/unit.c
+++ b/src/core/unit.c
@@ -162,7 +162,6 @@ static void unit_init(Unit *u) {
                 cc->blockio_accounting = u->manager->default_blockio_accounting;
                 cc->memory_accounting = u->manager->default_memory_accounting;
                 cc->tasks_accounting = u->manager->default_tasks_accounting;
-                cc->ip_accounting = u->manager->default_ip_accounting;
 
                 if (u->type != UNIT_SLICE)
                         cc->tasks_max = u->manager->default_tasks_max;

--- a/src/shared/bpf-program.c
+++ b/src/shared/bpf-program.c
@@ -94,6 +94,24 @@ int bpf_program_load_kernel(BPFProgram *p, char *log_buf, size_t log_size) {
         return 0;
 }
 
+int bpf_program_get_pinned(BPFProgram *p, const char *pathname) {
+
+        assert(p);
+        assert(pathname);
+
+        assert(p->kernel_fd < 0);
+
+        union bpf_attr attr = {
+                .pathname = PTR_TO_UINT64(pathname),
+        };
+
+        p->kernel_fd = bpf(BPF_OBJ_GET, &attr, sizeof(attr));
+        if (p->kernel_fd < 0)
+                return -errno;
+
+        return 0;
+}
+
 int bpf_program_cgroup_attach(BPFProgram *p, int type, const char *path, uint32_t flags) {
         _cleanup_free_ char *copy = NULL;
         _cleanup_close_ int fd = -1;

--- a/src/shared/bpf-program.h
+++ b/src/shared/bpf-program.h
@@ -31,6 +31,7 @@ BPFProgram *bpf_program_ref(BPFProgram *p);
 
 int bpf_program_add_instructions(BPFProgram *p, const struct bpf_insn *insn, size_t count);
 int bpf_program_load_kernel(BPFProgram *p, char *log_buf, size_t log_size);
+int bpf_program_get_pinned(BPFProgram *p, const char *pathname);
 
 int bpf_program_cgroup_attach(BPFProgram *p, int type, const char *path, uint32_t flags);
 int bpf_program_cgroup_detach(BPFProgram *p);

--- a/src/shared/bus-unit-util.c
+++ b/src/shared/bus-unit-util.c
@@ -383,7 +383,7 @@ static int bus_append_cgroup_property(sd_bus_message *m, const char *field, cons
 
         if (STR_IN_SET(field,
                        "CPUAccounting", "MemoryAccounting", "IOAccounting", "BlockIOAccounting",
-                       "TasksAccounting", "IPAccounting"))
+                       "TasksAccounting", "IPAccounting", "IPIngressFilterBPF", "IPEgressFilterBPF"))
 
                 return bus_append_parse_boolean(m, field, eq);
 

--- a/src/test/test-bpf.c
+++ b/src/test/test-bpf.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
 
         unit_dump(u, stdout, NULL);
 
-        r = bpf_firewall_compile(u);
+        r = bpf_firewall_prepare(u);
         if (IN_SET(r, -ENOTTY, -ENOSYS, -EPERM))
                 return log_tests_skipped("Kernel doesn't support the necessary bpf bits (masked out via seccomp?)");
         assert_se(r >= 0);


### PR DESCRIPTION
Adds options `IPIngressFilterBPF` and `IPEgressFilterBPF` to install custom BPF programs to a cgroup. The filters are (XXX: will be) loaded from `/sys/fs/bpf/systemd/<unit-name>/ip-{in,e}gress-filter`.

The new options extend the `bpf-firewall.{h,c}` controller and looks to the new `CGroupContext` variables `ip_{in,e}gress_filter_bpf` to see if the custom programs or the simplified `IPAccounting` and `IPAddress{Allow,Deny}` need to be installed.
